### PR TITLE
Use cve.org and format reporting

### DIFF
--- a/.github/workflows/ghes-cve-check.yml
+++ b/.github/workflows/ghes-cve-check.yml
@@ -85,25 +85,63 @@ jobs:
             if response.status_code == 200:
                 result = response.json()
                 if 'errors' in result or not result['data']['securityAdvisories']['nodes']:
-                    debug_print(f"No advisories found in GitHub for CVE {cve}, using Ubuntu URL.")
-                    return get_ubuntu_advisory_by_cve(cve), "Ubuntu"
+                    debug_print(f"No advisories found in GitHub for CVE {cve}, querying cve.org.")
+                    return get_cve_org_advisory_by_cve(cve), "cve.org"
                 debug_print(f"Advisories for CVE {cve} received from GitHub:", json.dumps(result, indent=2))
                 return result, "GitHub"
             else:
                 raise Exception(f"Query failed with status code {response.status_code}: {response.text}")
 
-        def get_ubuntu_advisory_by_cve(cve):
-            url = f"https://ubuntu.com/security/{cve}"
-            debug_print(f"Constructed URL: {url}")
-            return url
+        def get_cve_org_advisory_by_cve(cve):
+            url = f"https://cveawg.mitre.org/api/cve/{cve}"
+            debug_print(f"Fetching CVE data from cve.org API for {cve}")
+            try:
+                response = requests.get(url)
+                debug_print(f"Response Status Code: {response.status_code}")
 
-        def is_vulnerable(package_name, package_version, advisory_data):
-            for node in advisory_data.get('data', {}).get('securityAdvisories', {}).get('nodes', []):
-                for vulnerability in node.get('vulnerabilities', {}).get('nodes', []):
-                    if package_name == vulnerability['package']['name']:
-                        # Implement version comparison logic here
-                        debug_print(f"Package {package_name} is vulnerable. Affected range: {vulnerability['vulnerableVersionRange']}")
-                        return True, vulnerability['vulnerableVersionRange']
+                if response.status_code == 200:
+                    cve_data = response.json()
+                    debug_print(f"CVE data received: {json.dumps(cve_data, indent=2)}")
+                    return cve_data
+                elif response.status_code == 404:
+                    debug_print(f"CVE {cve} not found in cve.org database.")
+                    return None
+                else:
+                    debug_print(f"Failed to fetch data: {response.text}")
+                    raise Exception(f"Failed to fetch CVE data from cve.org with status code {response.status_code}: {response.text}")
+            except requests.exceptions.RequestException as e:
+                debug_print(f"RequestException occurred: {e}")
+                raise Exception(f"An error occurred while fetching CVE data: {e}")
+
+        def is_vulnerable(package_name, package_version, advisory_data, source):
+            if source == "GitHub":
+                for node in advisory_data.get('data', {}).get('securityAdvisories', {}).get('nodes', []):
+                    for vulnerability in node.get('vulnerabilities', {}).get('nodes', []):
+                        if package_name == vulnerability['package']['name']:
+                            # Implement version comparison logic here
+                            debug_print(f"Package {package_name} is vulnerable. Affected range: {vulnerability['vulnerableVersionRange']}")
+                            return True, vulnerability['vulnerableVersionRange']
+            elif source == "cve.org":
+                if advisory_data:
+                    descriptions = advisory_data.get('containers', {}).get('cna', {}).get('descriptions', [])
+                    fixed_versions = []
+                    for desc in descriptions:
+                        description_text = desc.get('value', '')
+                        # Updated regex to capture versions including digits, dots, commas, spaces, and 'and'
+                        matches = re.findall(r'fixed in versions? ([\d\.\s, and]+)', description_text, re.IGNORECASE)
+                        if matches:
+                            for match in matches:
+                                # Split versions by commas or 'and'
+                                versions = re.split(r',\s*|\s+and\s+', match.strip())
+                                # Clean up versions by stripping whitespace
+                                versions = [v.strip() for v in versions if v.strip()]
+                                fixed_versions.extend(versions)
+                    if fixed_versions:
+                        debug_print(f"Found fixed versions: {fixed_versions}")
+                        return True, fixed_versions
+                    else:
+                        debug_print("No fixed versions found in CVE descriptions.")
+                        return False, None
             return False, None
 
         def generate_report(dependencies, cves):
@@ -115,22 +153,32 @@ jobs:
                 report.append(f"CVE: {cve}")
                 advisory_data, source = get_advisory_by_cve(cve)
                 report.append(f"Source: {source}")
-                if source == "Ubuntu":
-                    report.append(f"Vulnerability undetermined")
-                    report.append(f"Please check the Ubuntu advisory page: {advisory_data}")
-                else:
+                references = [
+                    f"https://www.cve.org/CVERecord?id={cve}",
+                    f"https://github.com/advisories?query={cve}"
+                ]
+                if source == "GitHub":
                     affected_packages = []
                     for package_name, package_version in dependencies.items():
-                        vulnerable, version_range = is_vulnerable(package_name, package_version, advisory_data)
+                        vulnerable, version_range = is_vulnerable(package_name, package_version, advisory_data, source)
                         if vulnerable:
-                            affected_packages.append(f"WARNING {package_name} {package_version} is vulnerable (Affected range: {version_range})")
+                            affected_packages.append(f"WARNING: {package_name} {package_version} is vulnerable (Affected range: {version_range})")
                     if affected_packages:
                         report.extend(affected_packages)
                     else:
-                        report.append("No vulnerabilities found for the current GHES version.")
+                        report.append("No vulnerabilities found for the scanned GHES version.")
+                elif source == "cve.org":
+                    vulnerable, fixed_versions = is_vulnerable(None, None, advisory_data, source)
+                    if vulnerable and fixed_versions:
+                        report.append(f"Fixed in versions: {', '.join(fixed_versions)}.")
+                    else:
+                        report.append("Details undetermined. Update to latest patch release.")
+                report.append("References:")
+                report.extend(references)
                 report.append("")
-            report.append("")    
-            report.append("Note: If a package was marked vulnerable, but the version is good, there might be multiple installations!")
+            report.append("")
+            report.append("Note: For CVEs sourced from cve.org, please review the details manually as package information may be incomplete.")
+            report.append("      Packages marked vulnerable when their version looks good might be due to being installed in multiple locations.")
             return "\n".join(report)
 
         def save_report(report, filename="vulnerability_report.txt"):
@@ -162,7 +210,7 @@ jobs:
         VERSION: ${{ inputs.version }}
         CVES: ${{ inputs.cves }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DEBUG: 'false' # Enable debugging output
+        DEBUG: 'true' # Enable debugging output
 
     - name: Upload Report
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Swapped out Ubuntu's sources for cve.org, and updating reporting.

This pull request updates the `.github/workflows/ghes-cve-check.yml` file to improve how CVE advisories are fetched and processed. The changes include replacing the Ubuntu advisory source with cve.org, enhancing the vulnerability detection logic, and updating the report generation to include more detailed references and debugging information.