### PR TITLE
Update references using mitre.org

### DIFF
--- a/.github/workflows/ghes-cve-check.yml
+++ b/.github/workflows/ghes-cve-check.yml
@@ -85,8 +85,8 @@ jobs:
             if response.status_code == 200:
                 result = response.json()
                 if 'errors' in result or not result['data']['securityAdvisories']['nodes']:
-                    debug_print(f"No or unreviewed advisories found in GitHub for CVE {cve}, querying cve.org.")
-                    return get_cve_org_advisory_by_cve(cve), "cve.org"
+                    debug_print(f"No or unreviewed advisories found in GitHub for CVE {cve}, querying mitre.org.")
+                    return get_cve_org_advisory_by_cve(cve), "mitre.org"
                 debug_print(f"Advisories for CVE {cve} received from GitHub:", json.dumps(result, indent=2))
                 return result, "GitHub"
             else:
@@ -94,7 +94,7 @@ jobs:
 
         def get_cve_org_advisory_by_cve(cve):
             url = f"https://cveawg.mitre.org/api/cve/{cve}"
-            debug_print(f"Fetching CVE data from cve.org API for {cve}")
+            debug_print(f"Fetching CVE data from mitre.org API for {cve}")
             try:
                 response = requests.get(url)
                 debug_print(f"Response Status Code: {response.status_code}")
@@ -104,11 +104,11 @@ jobs:
                     debug_print(f"CVE data received: {json.dumps(cve_data, indent=2)}")
                     return cve_data
                 elif response.status_code == 404:
-                    debug_print(f"CVE {cve} not found in cve.org database.")
+                    debug_print(f"CVE {cve} not found in mitre.org database.")
                     return None
                 else:
                     debug_print(f"Failed to fetch data: {response.text}")
-                    raise Exception(f"Failed to fetch CVE data from cve.org with status code {response.status_code}: {response.text}")
+                    raise Exception(f"Failed to fetch CVE data from mitre.org with status code {response.status_code}: {response.text}")
             except requests.exceptions.RequestException as e:
                 debug_print(f"RequestException occurred: {e}")
                 raise Exception(f"An error occurred while fetching CVE data: {e}")
@@ -121,7 +121,7 @@ jobs:
                             # Implement version comparison logic here
                             debug_print(f"Package {package_name} is vulnerable. Affected range: {vulnerability['vulnerableVersionRange']}")
                             return True, vulnerability['vulnerableVersionRange']
-            elif source == "cve.org":
+            elif source == "mitre.org":
                 if advisory_data:
                     descriptions = advisory_data.get('containers', {}).get('cna', {}).get('descriptions', [])
                     fixed_versions = []
@@ -155,6 +155,7 @@ jobs:
                 report.append(f"Source: {source}")
                 references = [
                     f"https://www.cve.org/CVERecord?id={cve}",
+                    f"https://cveawg.mitre.org/api/cve/{cve}",
                     f"https://github.com/advisories?query={cve}"
                 ]
                 if source == "GitHub":
@@ -167,7 +168,7 @@ jobs:
                         report.extend(affected_packages)
                     else:
                         report.append("No vulnerabilities found for the scanned GHES version.")
-                elif source == "cve.org":
+                elif source == "mitre.org":
                     vulnerable, fixed_versions = is_vulnerable(None, None, advisory_data, source)
                     if vulnerable and fixed_versions:
                         report.append(f"Fixed in versions: {', '.join(fixed_versions)}.")
@@ -177,7 +178,7 @@ jobs:
                 report.extend(references)
                 report.append("")
             report.append("")
-            report.append("Note: For CVEs sourced from cve.org, please review the details manually as package information may be incomplete.")
+            report.append("Note: For CVEs sourced from mitre.org, please review the details manually as package information may be incomplete.")
             report.append("      Packages marked vulnerable when their version looks good might be due to being installed in multiple locations.")
             return "\n".join(report)
 


### PR DESCRIPTION
This pull request updates the CVE check workflow to use `mitre.org` instead of `cve.org` for querying CVE data. The most important changes include updating debug messages, exception messages, and references to reflect this change.